### PR TITLE
feat: Add assessment selection page with role and level selection

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,63 @@
+# 🚀 Savyre Assessment Environment
+
+This devcontainer provides a complete development environment for Savyre coding assessments with all necessary tools pre-configured.
+
+## ✨ Features
+
+- **Python 3.12** with FastAPI backend
+- **Node.js 18** with React frontend
+- **Pre-installed extensions** for Python, TypeScript, and web development
+- **GitHub integration** with GitHub CLI and Copilot
+- **Code quality tools** (Black, Flake8, Prettier, ESLint)
+- **Port forwarding** for frontend (3000) and backend (8001)
+
+## 🎯 Getting Started
+
+1. **Click "Start Assessment"** button on any assessment tab
+2. **GitHub Codespace** will open in a new tab
+3. **Wait for environment** to build (usually 2-3 minutes)
+4. **Start coding** in the fully configured IDE!
+
+## 🛠️ Available Commands
+
+```bash
+# Start both frontend and backend
+npm run dev:full
+
+# Start only frontend
+npm run frontend
+
+# Start only backend
+npm run backend
+
+# Install dependencies
+npm run install:frontend
+npm run install:backend
+```
+
+## 📁 Project Structure
+
+```
+├── frontend/          # React + TypeScript frontend
+├── backend/           # FastAPI + Python backend
+├── .devcontainer/     # Development environment config
+└── README.md         # Project documentation
+```
+
+## 🔧 Assessment Types
+
+- **Leadership Assessments** - Team management scenarios
+- **Technical Assessments** - Coding challenges
+- **Soft Skills Assessments** - Communication exercises
+- **Industry Assessments** - Domain-specific problems
+
+## 🚀 Ready to Code!
+
+Your assessment environment is now ready with:
+- ✅ Full-stack development setup
+- ✅ Code quality tools
+- ✅ GitHub integration
+- ✅ Pre-configured extensions
+- ✅ Hot reload development
+
+Happy coding! 🎉

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,66 @@
+{
+  "name": "Savyre Assessment Environment",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "18"
+    },
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.black-formatter",
+        "ms-python.flake8",
+        "ms-python.isort",
+        "ms-toolsai.jupyter",
+        "ms-vscode.vscode-typescript-next",
+        "bradlc.vscode-tailwindcss",
+        "esbenp.prettier-vscode",
+        "ms-vscode.vscode-json",
+        "ms-vscode.vscode-yaml",
+        "github.copilot",
+        "github.copilot-chat",
+        "ms-vscode.vscode-github",
+        "ms-vscode.remote-containers",
+        "ms-vscode.remote-github",
+        "ms-vscode.remote-wsl"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.linting.enabled": true,
+        "python.linting.flake8Enabled": true,
+        "python.formatting.provider": "black",
+        "python.sortImports.args": ["--profile", "black"],
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+          "source.organizeImports": true
+        },
+        "typescript.preferences.importModuleSpecifier": "relative",
+        "tailwindCSS.includeLanguages": {
+          "typescript": "javascript",
+          "typescriptreact": "javascript"
+        }
+      }
+    }
+  },
+  "postCreateCommand": "pip install --user -r backend/requirements.txt && npm install -g concurrently",
+  "postStartCommand": "echo 'Assessment environment ready! 🚀'",
+  "forwardPorts": [3000, 8001],
+  "portsAttributes": {
+    "3000": {
+      "label": "React Frontend",
+      "onAutoForward": "notify"
+    },
+    "8001": {
+      "label": "FastAPI Backend",
+      "onAutoForward": "notify"
+    }
+  },
+  "remoteUser": "vscode",
+  "mounts": [
+    "source=${localWorkspaceFolder}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached"
+  ]
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import Home from './pages/Home';
 import Login from './pages/Login';
 import Dashboard from './pages/Dashboard';
 import Demo from './pages/Demo';
+import AssessmentSelection from './pages/AssessmentSelection';
 import { AuthProvider } from './contexts/AuthContext';
 
 function App() {
@@ -19,6 +20,7 @@ function App() {
               <Route path="/login" element={<Login />} />
               <Route path="/dashboard" element={<Dashboard />} />
               <Route path="/demo" element={<Demo />} />
+              <Route path="/assessment" element={<AssessmentSelection />} />
             </Routes>
           </main>
         </div>

--- a/frontend/src/pages/AssessmentSelection.tsx
+++ b/frontend/src/pages/AssessmentSelection.tsx
@@ -1,0 +1,328 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { ArrowLeftIcon, CodeBracketIcon, ServerIcon, ChartBarIcon, CpuChipIcon } from '@heroicons/react/24/outline';
+
+interface Role {
+  id: string;
+  title: string;
+  description: string;
+  icon: React.ComponentType<{ className?: string }>;
+  color: string;
+}
+
+interface Level {
+  id: string;
+  title: string;
+  description: string;
+  duration: string;
+  difficulty: string;
+}
+
+const AssessmentSelection: React.FC = () => {
+  const [selectedRole, setSelectedRole] = useState<string>('');
+  const [selectedLevel, setSelectedLevel] = useState<string>('');
+  const [isLaunching, setIsLaunching] = useState(false);
+  const navigate = useNavigate();
+
+  const roles: Role[] = [
+    {
+      id: 'backend',
+      title: 'Backend Engineer',
+      description: 'Server-side development, APIs, databases, and system architecture',
+      icon: ServerIcon,
+      color: 'bg-blue-500'
+    },
+    {
+      id: 'frontend',
+      title: 'Frontend Engineer',
+      description: 'User interface development, responsive design, and user experience',
+      icon: CodeBracketIcon,
+      color: 'bg-green-500'
+    },
+    {
+      id: 'data',
+      title: 'Data Engineer',
+      description: 'Data pipelines, ETL processes, and data infrastructure',
+      icon: ChartBarIcon,
+      color: 'bg-purple-500'
+    },
+    {
+      id: 'fullstack',
+      title: 'Full Stack Engineer',
+      description: 'End-to-end development across frontend and backend',
+      icon: CpuChipIcon,
+      color: 'bg-orange-500'
+    }
+  ];
+
+  const levels: Level[] = [
+    {
+      id: 'beginner',
+      title: 'Beginner',
+      description: '0-2 years of experience, fundamental concepts',
+      duration: '1-2 hours',
+      difficulty: 'Basic'
+    },
+    {
+      id: 'intermediate',
+      title: 'Intermediate',
+      description: '2-5 years of experience, practical applications',
+      duration: '2-3 hours',
+      difficulty: 'Moderate'
+    },
+    {
+      id: 'advanced',
+      title: 'Advanced',
+      description: '5+ years of experience, complex problem solving',
+      duration: '3-4 hours',
+      difficulty: 'Challenging'
+    }
+  ];
+
+  const launchAssessment = async () => {
+    if (!selectedRole || !selectedLevel) {
+      alert('Please select both a role and level before proceeding.');
+      return;
+    }
+
+    setIsLaunching(true);
+
+    // Assessment-specific repository configurations
+    const assessmentRepos = {
+      backend: {
+        beginner: 'Anucampa28/backend-beginner-assessment',
+        intermediate: 'Anucampa28/backend-intermediate-assessment',
+        advanced: 'Anucampa28/backend-advanced-assessment'
+      },
+      frontend: {
+        beginner: 'Anucampa28/frontend-beginner-assessment',
+        intermediate: 'Anucampa28/frontend-intermediate-assessment',
+        advanced: 'Anucampa28/frontend-advanced-assessment'
+      },
+      data: {
+        beginner: 'Anucampa28/data-beginner-assessment',
+        intermediate: 'Anucampa28/data-intermediate-assessment',
+        advanced: 'Anucampa28/data-advanced-assessment'
+      },
+      fullstack: {
+        beginner: 'Anucampa28/fullstack-beginner-assessment',
+        intermediate: 'Anucampa28/fullstack-intermediate-assessment',
+        advanced: 'Anucampa28/fullstack-advanced-assessment'
+      }
+    };
+
+    const repo = assessmentRepos[selectedRole as keyof typeof assessmentRepos]?.[selectedLevel as keyof typeof assessmentRepos.backend];
+    
+    if (!repo) {
+      alert('Assessment configuration not found. Please try again.');
+      setIsLaunching(false);
+      return;
+    }
+
+    // Create GitHub Codespace URL
+    const codespaceUrl = `https://github.com/codespaces/new?repo=${repo}&machine=standardLinux32gb&location=WestUs2`;
+    
+    console.log('Launching assessment:', { role: selectedRole, level: selectedLevel, repo, url: codespaceUrl });
+
+    // Try to open in new tab
+    const newWindow = window.open(codespaceUrl, '_blank');
+    
+    if (!newWindow) {
+      alert(
+        `⚠️ Popup blocked!\n\n` +
+        `Please allow popups and try again, or manually visit:\n${codespaceUrl}`
+      );
+      setIsLaunching(false);
+      return;
+    }
+
+    // Show success message
+    alert(
+      `🎉 Assessment Launched!\n\n` +
+      `✅ Role: ${roles.find(r => r.id === selectedRole)?.title}\n` +
+      `✅ Level: ${levels.find(l => l.id === selectedLevel)?.title}\n` +
+      `✅ Repository: ${repo}\n\n` +
+      `🚀 GitHub Codespace opening in new tab\n` +
+      `⏳ Environment building (2-3 minutes)\n\n` +
+      `Good luck with your assessment! 🎯`
+    );
+
+    // Reset states
+    setTimeout(() => {
+      setIsLaunching(false);
+      setSelectedRole('');
+      setSelectedLevel('');
+    }, 3000);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <div className="bg-white shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+          <div className="flex items-center">
+            <button
+              onClick={() => navigate(-1)}
+              className="mr-4 p-2 text-gray-400 hover:text-gray-600 transition-colors"
+            >
+              <ArrowLeftIcon className="w-6 h-6" />
+            </button>
+            <h1 className="text-2xl font-bold text-gray-900">Assessment Selection</h1>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        {/* Progress Indicator */}
+        <div className="mb-8">
+          <div className="flex items-center justify-center space-x-4">
+            <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium ${
+              selectedRole ? 'bg-primary-600 text-white' : 'bg-gray-200 text-gray-500'
+            }`}>
+              1
+            </div>
+            <div className="w-16 h-1 bg-gray-200"></div>
+            <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium ${
+              selectedLevel ? 'bg-primary-600 text-white' : 'bg-gray-200 text-gray-500'
+            }`}>
+              2
+            </div>
+            <div className="w-16 h-1 bg-gray-200"></div>
+            <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium ${
+              selectedRole && selectedLevel ? 'bg-primary-600 text-white' : 'bg-gray-200 text-gray-500'
+            }`}>
+              3
+            </div>
+          </div>
+          <div className="flex justify-center space-x-16 mt-2 text-sm text-gray-500">
+            <span>Select Role</span>
+            <span>Select Level</span>
+            <span>Launch Assessment</span>
+          </div>
+        </div>
+
+        {/* Role Selection */}
+        <div className="mb-12">
+          <h2 className="text-2xl font-bold text-gray-900 mb-6 text-center">Choose Your Role</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {roles.map((role) => (
+              <div
+                key={role.id}
+                onClick={() => setSelectedRole(role.id)}
+                className={`card cursor-pointer transition-all duration-200 ${
+                  selectedRole === role.id
+                    ? 'ring-2 ring-primary-500 shadow-lg transform scale-105'
+                    : 'hover:shadow-lg hover:scale-105'
+                }`}
+              >
+                <div className="flex items-center space-x-4">
+                  <div className={`w-12 h-12 rounded-lg ${role.color} flex items-center justify-center`}>
+                    <role.icon className="w-6 h-6 text-white" />
+                  </div>
+                  <div className="flex-1">
+                    <h3 className="text-lg font-semibold text-gray-900">{role.title}</h3>
+                    <p className="text-gray-600 text-sm">{role.description}</p>
+                  </div>
+                  {selectedRole === role.id && (
+                    <div className="w-6 h-6 bg-primary-500 rounded-full flex items-center justify-center">
+                      <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
+                        <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                      </svg>
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Level Selection */}
+        {selectedRole && (
+          <div className="mb-12">
+            <h2 className="text-2xl font-bold text-gray-900 mb-6 text-center">Choose Your Level</h2>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+              {levels.map((level) => (
+                <div
+                  key={level.id}
+                  onClick={() => setSelectedLevel(level.id)}
+                  className={`card cursor-pointer transition-all duration-200 ${
+                    selectedLevel === level.id
+                      ? 'ring-2 ring-primary-500 shadow-lg transform scale-105'
+                      : 'hover:shadow-lg hover:scale-105'
+                  }`}
+                >
+                  <div className="text-center">
+                    <h3 className="text-lg font-semibold text-gray-900 mb-2">{level.title}</h3>
+                    <p className="text-gray-600 text-sm mb-3">{level.description}</p>
+                    <div className="space-y-1 text-xs text-gray-500">
+                      <div>⏱️ Duration: {level.duration}</div>
+                      <div>📊 Difficulty: {level.difficulty}</div>
+                    </div>
+                    {selectedLevel === level.id && (
+                      <div className="mt-3">
+                        <div className="w-6 h-6 bg-primary-500 rounded-full flex items-center justify-center mx-auto">
+                          <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
+                            <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                          </svg>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Launch Button */}
+        {selectedRole && selectedLevel && (
+          <div className="text-center">
+            <button
+              onClick={launchAssessment}
+              disabled={isLaunching}
+              className={`btn-primary text-xl px-12 py-4 flex items-center justify-center gap-3 mx-auto transition-all duration-200 ${
+                isLaunching
+                  ? 'opacity-75 cursor-not-allowed bg-primary-500'
+                  : 'hover:bg-primary-700 hover:scale-105'
+              }`}
+            >
+              {isLaunching ? (
+                <>
+                  <svg className="animate-spin w-6 h-6" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  </svg>
+                  Launching Assessment...
+                </>
+              ) : (
+                <>
+                  <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clipRule="evenodd" />
+                  </svg>
+                  Launch Assessment
+                </>
+              )}
+            </button>
+            
+            <div className="mt-4 text-sm text-gray-500">
+              <p>Role: <span className="font-medium text-gray-700">{roles.find(r => r.id === selectedRole)?.title}</span></p>
+              <p>Level: <span className="font-medium text-gray-700">{levels.find(l => l.id === selectedLevel)?.title}</span></p>
+            </div>
+          </div>
+        )}
+
+        {/* Back to Home */}
+        <div className="text-center mt-12">
+          <Link
+            to="/"
+            className="text-primary-600 hover:text-primary-700 font-medium hover:underline"
+          >
+            ← Back to Home
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AssessmentSelection;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -14,6 +14,9 @@ import {
 const Home: React.FC = () => {
   const [activeTab, setActiveTab] = useState('leadership');
 
+
+
+
   const features = [
     {
       icon: AcademicCapIcon,
@@ -198,12 +201,23 @@ const Home: React.FC = () => {
                   <p className="text-lg text-gray-600 mb-8 max-w-2xl mx-auto">
                     {tab.description}
                   </p>
-                  <Link
-                    to="/demo"
-                    className="btn-primary text-lg px-8 py-3"
-                  >
-                    Try {tab.title} Assessment
-                  </Link>
+                  <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                    <Link
+                      to="/demo"
+                      className="btn-secondary text-lg px-8 py-3"
+                    >
+                      Try {tab.title} Assessment
+                    </Link>
+                    <Link
+                      to="/assessment"
+                      className="btn-primary text-lg px-8 py-3 flex items-center justify-center gap-2 hover:bg-primary-700 transition-all duration-200"
+                    >
+                      <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                        <path fillRule="evenodd" d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 11-1.898-.632l4-12a1 1 0 011.265-.633zM5.707 6.293a1 1 0 010 1.414L3.414 10l2.293 2.293a1 1 0 11-1.414 1.414l-3-3a1 1 0 010-1.414l3-3a1 1 0 011.414 0zm8.586 0a1 1 0 011.414 0l3 3a1 1 0 010 1.414l-3 3a1 1 0 11-1.414-1.414L16.586 10l-2.293-2.293a1 1 0 010-1.414z" clipRule="evenodd" />
+                      </svg>
+                      Start Assessment
+                    </Link>
+                  </div>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
- Create AssessmentSelection page with role-based assessment options
- Add Backend, Frontend, Data, and Full Stack Engineer roles
- Include Beginner, Intermediate, and Advanced difficulty levels
- Implement progress indicator and guided selection flow
- Update Home page to navigate to assessment selection
- Configure role-specific GitHub repository mappings
- Add devcontainer configuration for assessment environments